### PR TITLE
fix: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: "npm"
           cache-dependency-path: ./page/package-lock.json
       - name: Install package
@@ -37,11 +37,11 @@ jobs:
         run: npm run build
         working-directory: ./page
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: "./page/build"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
    - Update actions/checkout from v3 to v4
    - Update actions/setup-node from v3 to v4
    - Update Node.js version from 16 to 20
    - Update actions/configure-pages from v3 to v4
    - Update actions/upload-pages-artifact from v1 to v3
    - Update actions/deploy-pages from v2 to v4

    Resolves deprecation warnings for GitHub Actions workflow